### PR TITLE
Fixed inserting Unix EOL

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ wiring.prependToFile = function prependToFile(path, tagName, content) {
  * @param {String|Array} searchPath
  */
 
-wiring.generateBlock = function generateBlock(blockType, optimizedPath, filesBlock, searchPath) {
+wiring.generateBlock = function generateBlock(blockType, optimizedPath, filesBlock, searchPath, eolChar) {
   var blockStart;
   var blockEnd;
   var blockSearchPath = '';
@@ -124,8 +124,8 @@ wiring.generateBlock = function generateBlock(blockType, optimizedPath, filesBlo
     blockSearchPath = '(' + searchPath + ')';
   }
 
-  blockStart = '\n' + wiring.appendIndent('<!-- build:' + blockType + blockSearchPath + ' ' + optimizedPath + ' -->\n');
-  blockEnd = wiring.appendIndent('<!-- endbuild -->\n');
+  blockStart = eolChar + wiring.appendIndent('<!-- build:' + blockType + blockSearchPath + ' ' + optimizedPath + ' -->' + eolChar);
+  blockEnd = wiring.appendIndent('<!-- endbuild -->' + eolChar);
   return blockStart + filesBlock + blockEnd;
 };
 
@@ -147,6 +147,7 @@ wiring.appendFiles = function appendFiles(htmlOrOptions, fileType, optimizedPath
   var updatedContent;
   var html = htmlOrOptions;
   var files = '';
+  var eolChar;
 
   if (typeof htmlOrOptions === 'object') {
     html = htmlOrOptions.html;
@@ -159,17 +160,23 @@ wiring.appendFiles = function appendFiles(htmlOrOptions, fileType, optimizedPath
 
   attrs = this.attributes(attrs);
 
+  if (html.indexOf('\r\n') > 0) {
+    eolChar = '\r\n';
+  } else {
+    eolChar = '\n';
+  }
+
   if (fileType === 'js') {
     sourceFileList.forEach(function (el) {
-      files += wiring.appendIndent('<script ' + attrs + ' src="' + el + '"></script>\n');
+      files += wiring.appendIndent('<script ' + attrs + ' src="' + el + '"></script>' + eolChar);
     });
-    blocks = this.generateBlock('js', optimizedPath, files, searchPath);
+    blocks = this.generateBlock('js', optimizedPath, files, searchPath, eolChar);
     updatedContent = this.append(html, 'body', blocks);
   } else if (fileType === 'css') {
     sourceFileList.forEach(function (el) {
-      files += wiring.appendIndent('<link ' + attrs + ' rel="stylesheet" href="' + el + '">\n');
+      files += wiring.appendIndent('<link ' + attrs + ' rel="stylesheet" href="' + el + '">' + eolChar);
     });
-    blocks = this.generateBlock('css', optimizedPath, files, searchPath);
+    blocks = this.generateBlock('css', optimizedPath, files, searchPath, eolChar);
     updatedContent = this.append(html, 'head', blocks);
   }
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var util = require('util');
 var fs = require('fs');
 var path = require('path');
 var cheerio = require('cheerio');
+var detectNewline = require('detect-newline');
 
 /**
  * @mixin
@@ -29,7 +30,9 @@ var wiring = module.exports;
  */
 
 wiring.domUpdate = function domUpdate(html, tagName, content, mode) {
-  var $ = cheerio.load(html, { decodeEntities: false });
+  var $ = cheerio.load(html, {
+    decodeEntities: false
+  });
 
   if (content !== undefined) {
     if (mode === 'a') {
@@ -160,11 +163,7 @@ wiring.appendFiles = function appendFiles(htmlOrOptions, fileType, optimizedPath
 
   attrs = this.attributes(attrs);
 
-  if (html.indexOf('\r\n') > 0) {
-    eolChar = '\r\n';
-  } else {
-    eolChar = '\n';
-  }
+  eolChar = detectNewline(html);
 
   if (fileType === 'js') {
     sourceFileList.forEach(function (el) {

--- a/index.js
+++ b/index.js
@@ -30,9 +30,7 @@ var wiring = module.exports;
  */
 
 wiring.domUpdate = function domUpdate(html, tagName, content, mode) {
-  var $ = cheerio.load(html, {
-    decodeEntities: false
-  });
+  var $ = cheerio.load(html, { decodeEntities: false });
 
   if (content !== undefined) {
     if (mode === 'a') {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "index.js"
   ],
   "dependencies": {
-    "cheerio": "^0.19.0"
+    "cheerio": "^0.19.0",
+    "detect-newline": "^1.0.3"
   },
   "devDependencies": {
     "mocha": "^2.2.1",

--- a/test/fixtures/basic_html.html
+++ b/test/fixtures/basic_html.html
@@ -1,0 +1,1 @@
+<html><body></body></html>

--- a/test/wiring.js
+++ b/test/wiring.js
@@ -16,7 +16,7 @@ describe('generators.Base (actions/wiring)', function () {
     var res = wiring.generateBlock('js', 'main.js', [
       'path/file1.js',
       'path/file2.js'
-    ]);
+    ], undefined, '\n');
 
     assert.equal(res.trim(), '<!-- build:js main.js -->\npath/file1.js,path/file2.js    <!-- endbuild -->');
   });
@@ -25,7 +25,7 @@ describe('generators.Base (actions/wiring)', function () {
     var res = wiring.generateBlock('js', 'main.js', [
       'path/file1.js',
       'path/file2.js'
-    ], '.tmp/');
+    ], '.tmp/', '\n');
 
     assert.equal(res.trim(), '<!-- build:js(.tmp/) main.js -->\npath/file1.js,path/file2.js    <!-- endbuild -->');
   });
@@ -34,7 +34,7 @@ describe('generators.Base (actions/wiring)', function () {
     var res = wiring.generateBlock('js', 'main.js', [
       'path/file1.js',
       'path/file2.js'
-    ], ['.tmp/', 'dist/']);
+    ], ['.tmp/', 'dist/'], '\n');
 
     assert.equal(res.trim(), '<!-- build:js({.tmp/,dist/}) main.js -->\npath/file1.js,path/file2.js    <!-- endbuild -->');
   });
@@ -43,9 +43,45 @@ describe('generators.Base (actions/wiring)', function () {
     var html = '<html><body></body></html>';
     var res = wiring.appendFiles(html, 'js', 'out/file.js', ['in/file1.js', 'in/file2.js']);
     var fixture = fs.readFileSync(path.join(this.fixtures, 'js_block.html'),
-                                  'utf-8').trim();
+      'utf-8').trim();
 
     assert.textEqual(res, fixture);
+  });
+
+  it('append js files to an html with Windows EOL', function () {
+    var html = '<html><body></body></html>\r\n';
+    var res = wiring.appendFiles(html, 'js', 'out/file.js', ['in/file1.js', 'in/file2.js']);
+    var expected = '<html><body>\r\n' +
+      '    <!-- build:js out/file.js -->\r\n' +
+      '    <script src="in/file1.js"></script>\r\n' +
+      '    <script src="in/file2.js"></script>\r\n' +
+      '    <!-- endbuild -->\r\n' +
+      '</body></html>\r\n';
+
+    assert.equal(res, expected);
+  });
+
+  it('append js files to an html with Unix EOL', function () {
+    var html = '<html><body></body></html>\n';
+    var res = wiring.appendFiles(html, 'js', 'out/file.js', ['in/file1.js', 'in/file2.js']);
+    var expected = '<html><body>\n' +
+      '    <!-- build:js out/file.js -->\n' +
+      '    <script src="in/file1.js"></script>\n' +
+      '    <script src="in/file2.js"></script>\n' +
+      '    <!-- endbuild -->\n' +
+      '</body></html>\n';
+
+    assert.equal(res, expected);
+  });
+
+  it('append js files to an html file', function () {
+    var html = fs.readFileSync(path.join(this.fixtures, 'basic_html.html'),
+      'utf-8');
+    var res = wiring.appendFiles(html, 'js', 'out/file.js', ['in/file1.js', 'in/file2.js']);
+    var fixture = fs.readFileSync(path.join(this.fixtures, 'js_block.html'),
+      'utf-8');
+
+    assert.equal(res, fixture);
   });
 
   it('appendFiles work the same using the object syntax', function () {


### PR DESCRIPTION
- Added eolChar parameter to wiring.generateBlock function
- Replaced fixed Unix EOL with eolChar variable
- Assigned eolChar value depending on HTML string
- Added Unix EOL to tests using generateBlock function
- Added tests with an HTML string using Windows and Unix EOL
- Added test using a real HTML file as input

Based on NodeJS code, there is only 2 possible EOL:
https://github.com/joyent/node/blob/master/lib/os.js#L66

I also noticed that tests using fixtures uses **textEqual** instead of **equal**.
This could be changed if the file **basic_html.html** is used as input instead of a string. Also **trim** function could be removed.
